### PR TITLE
Fix "Language" title position

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -101,7 +101,7 @@
                     <div class="col-xs-6 col-md-3">
                         <img src="img/logo-gbn.png" />
                     </div>
-
+                    <div class="clearfix"></div>
                     <h4>Languages:</h4>
                     <div class="margin-left-5px">C#, JavaScript</div>
                     <h4>Technologies:</h4>


### PR DESCRIPTION
Added a clearfix before `<h4>Language:</h4>` to prevent an incorrect behaviour with the previous floating elements (Bootstrap columns)
